### PR TITLE
Update engine API to "The Talladega Curse" release

### DIFF
--- a/api.go
+++ b/api.go
@@ -185,7 +185,7 @@ type ForkchoiceUpdatedResult struct {
 	PayloadID *PayloadID `json:"payloadId"`
 }
 
-func GetPayload(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger,
+func GetPayloadV1(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger,
 	payloadId PayloadID) (*ExecutionPayload, error) {
 
 	e := log.WithField("payload_id", payloadId)
@@ -210,7 +210,7 @@ func GetPayload(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger,
 	return &result, nil
 }
 
-func ExecutePayload(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger,
+func ExecutePayloadV1(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger,
 	payload *ExecutionPayload) (*ExecutePayloadResult, error) {
 
 	e := log.WithField("block_hash", payload.BlockHash)
@@ -225,7 +225,7 @@ func ExecutePayload(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLog
 	return &result, nil
 }
 
-func ForkchoiceUpdated(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger, head, safe, finalized Bytes32, payload *PayloadAttributes) (ForkchoiceUpdatedResult, error) {
+func ForkchoiceUpdatedV1(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger, head, safe, finalized Bytes32, payload *PayloadAttributes) (ForkchoiceUpdatedResult, error) {
 	params := ForkchoiceUpdatedParams{
 		HeadBlockHash:      head,
 		SafeBlockHash:      safe,

--- a/api.go
+++ b/api.go
@@ -84,6 +84,7 @@ func (b *BytesMax32) UnmarshalText(text []byte) error {
 	}
 	return (*hexutil.Bytes)(b).UnmarshalText(text)
 }
+
 func (b BytesMax32) MarshalText() ([]byte, error) {
 	return (hexutil.Bytes)(b).MarshalText()
 }
@@ -212,13 +213,13 @@ func ExecutePayload(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLog
 }
 
 func ForkchoiceUpdated(ctx context.Context, cl *rpc.Client, log logrus.Ext1FieldLogger, head, safe, finalized Bytes32, payload *PayloadAttributes) (ForkchoiceUpdatedResult, error) {
-	state := &ForkchoiceState{HeadBlockHash: head, SafeBlockHash: safe, FinalizedBlockHash: finalized}
+	heads := &ForkchoiceState{HeadBlockHash: head, SafeBlockHash: safe, FinalizedBlockHash: finalized}
 
 	e := log.WithField("head", head).WithField("safe", safe).WithField("finalized", finalized).WithField("payload", payload)
 	e.Debug("Sharing forkchoice-updated signal")
 
 	var result ForkchoiceUpdatedResult
-	err := cl.CallContext(ctx, &result, "engine_forkchoiceUpdatedV1", &state, &payload)
+	err := cl.CallContext(ctx, &result, "engine_forkchoiceUpdatedV1", &heads, &payload)
 	if err == nil {
 		e.Debug("Shared forkchoice-updated signal")
 		if payload != nil {

--- a/api.go
+++ b/api.go
@@ -97,7 +97,23 @@ type Uint256Quantity = uint256.Int
 
 type Data = hexutil.Bytes
 
-type PayloadID = hexutil.Bytes
+type PayloadID [8]byte
+
+func (b *PayloadID) UnmarshalJSON(text []byte) error {
+	return hexutil.UnmarshalFixedJSON(reflect.TypeOf(b), text, b[:])
+}
+
+func (b *PayloadID) UnmarshalText(text []byte) error {
+	return hexutil.UnmarshalFixedText("PayloadID", text, b[:])
+}
+
+func (b PayloadID) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(b[:]).MarshalText()
+}
+
+func (b PayloadID) String() string {
+	return hexutil.Encode(b[:])
+}
 
 type ExecutionPayload struct {
 	ParentHash    common.Hash     `json:"parentHash"`

--- a/api.go
+++ b/api.go
@@ -18,9 +18,7 @@ import (
 type ErrorCode int
 
 const (
-	ActionNotAllowed             = 2
-	UnknownBlock       ErrorCode = 4
-	UnavailablePayload ErrorCode = 5
+	UnavailablePayload ErrorCode = -32001
 )
 
 // received message isn't a valid request
@@ -247,11 +245,7 @@ func ForkchoiceUpdated(ctx context.Context, cl *rpc.Client, log logrus.Ext1Field
 		e = e.WithError(err)
 		if rpcErr, ok := err.(rpc.Error); ok {
 			code := ErrorCode(rpcErr.ErrorCode())
-			if code != UnknownBlock {
-				e.WithField("code", code).Warn("Unexpected error code in forkchoice-updated response")
-			} else {
-				e.Info("Unknown block in forkchoice-updated signal")
-			}
+			e.WithField("code", code).Warn("Unexpected error code in forkchoice-updated response")
 		} else {
 			e.Error("Failed to share forkchoice-updated signal")
 		}

--- a/consensus.go
+++ b/consensus.go
@@ -358,7 +358,6 @@ func (c *ConsensusCmd) mockExecution(log logrus.Ext1FieldLogger, block *types.Bl
 	}
 
 	ExecutePayload(ctx, c.engine, log, payload)
-	ConsensusValidated(ctx, c.engine, log, Bytes32(payload.BlockHash), ConsensusValid)
 }
 
 func dummyTxCreator(config *params.ChainConfig, bc core.ChainContext, statedb *state.StateDB, header *types.Header, cfg vm.Config) []*types.Transaction {

--- a/consensus.go
+++ b/consensus.go
@@ -310,15 +310,15 @@ func (c *ConsensusCmd) mockProposal(log logrus.Ext1FieldLogger, parent common.Ha
 		// send it back to execution layer for execution
 		ctx, cancel := context.WithTimeout(c.ctx, time.Second*20)
 		defer cancel()
-		execStatus, err := ExecutePayload(ctx, c.engine, log, payload)
+		res, err := ExecutePayload(ctx, c.engine, log, payload)
 		if err != nil {
 			log.WithError(err).Error("Failed to execute payload")
-		} else if execStatus == ExecutionValid {
+		} else if res.Status == ExecutionValid {
 			log.WithField("blockhash", block.Hash()).Debug("Processed payload in engine")
-		} else if execStatus == ExecutionInvalid {
+		} else if res.Status == ExecutionInvalid {
 			log.WithField("blockhash", block.Hash()).Error("Engine just produced payload and failed to execute it after!")
 		} else {
-			log.WithField("status", execStatus).Error("Unrecognized execution status")
+			log.WithField("status", res.Status).Error("Unrecognized execution status")
 		}
 	}
 }

--- a/consensus.go
+++ b/consensus.go
@@ -271,7 +271,7 @@ func (c *ConsensusCmd) RunNode() {
 					go func() {
 						c.mockExecution(slotLog, block)
 						latest := Bytes32(block.Hash())
-						ForkchoiceUpdated(c.ctx, c.engine, c.log, latest, latest, latest, nil)
+						ForkchoiceUpdatedV1(c.ctx, c.engine, c.log, latest, latest, latest, nil)
 					}()
 				}
 			}
@@ -310,7 +310,7 @@ func (c *ConsensusCmd) mockProposal(log logrus.Ext1FieldLogger, parent common.Ha
 		// send it back to execution layer for execution
 		ctx, cancel := context.WithTimeout(c.ctx, time.Second*20)
 		defer cancel()
-		res, err := ExecutePayload(ctx, c.engine, log, payload)
+		res, err := ExecutePayloadV1(ctx, c.engine, log, payload)
 		if err != nil {
 			log.WithError(err).Error("Failed to execute payload")
 		} else if res.Status == ExecutionValid {
@@ -333,7 +333,7 @@ func (c *ConsensusCmd) mockPrep(log logrus.Ext1FieldLogger, parent common.Hash, 
 		FeeRecipient: feeRecipient,
 	}
 	latest := Bytes32(parent)
-	res, err := ForkchoiceUpdated(c.ctx, c.engine, c.log, latest, latest, latest, &attributes)
+	res, err := ForkchoiceUpdatedV1(c.ctx, c.engine, c.log, latest, latest, latest, &attributes)
 	if err != nil {
 		log.WithError(err).Error("Failed to prepare and get payload, failed proposal")
 		return nil, nil
@@ -343,7 +343,7 @@ func (c *ConsensusCmd) mockPrep(log logrus.Ext1FieldLogger, parent common.Hash, 
 		return nil, nil
 	}
 
-	return GetPayload(ctx, c.engine, log, *res.PayloadID)
+	return GetPayloadV1(ctx, c.engine, log, *res.PayloadID)
 }
 
 func (c *ConsensusCmd) mockExecution(log logrus.Ext1FieldLogger, block *types.Block) {
@@ -358,7 +358,7 @@ func (c *ConsensusCmd) mockExecution(log logrus.Ext1FieldLogger, block *types.Bl
 		return
 	}
 
-	ExecutePayload(ctx, c.engine, log, payload)
+	ExecutePayloadV1(ctx, c.engine, log, payload)
 }
 
 func dummyTxCreator(config *params.ChainConfig, bc core.ChainContext, statedb *state.StateDB, header *types.Header, cfg vm.Config) []*types.Transaction {

--- a/engine.go
+++ b/engine.go
@@ -261,11 +261,6 @@ func (e *EngineBackend) ExecutePayload(ctx context.Context, payload *ExecutionPa
 	return &ExecutePayloadResult{Status: ExecutionValid}, nil
 }
 
-func (e *EngineBackend) ConsensusValidated(ctx context.Context, params *ConsensusValidatedParams) error {
-	e.log.WithField("params", params).Info("Consensus validated")
-	return nil
-}
-
 func (e *EngineBackend) ForkchoiceUpdated(ctx context.Context, params *ForkchoiceUpdatedParams) error {
 	e.log.WithField("params", params).Info("Forkchoice validated")
 	return nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -17,6 +17,7 @@
 package p2p
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"net"
@@ -215,10 +216,13 @@ func (c *Conn) Ping() error {
 	return err
 }
 
-func (c *Conn) KeepAlive(log *logrus.Logger) {
+func (c *Conn) KeepAlive(ctx context.Context, log logrus.Ext1FieldLogger) {
 	ticker := time.NewTicker(20 * time.Second)
 	for {
 		select {
+		case <-ctx.Done():
+			log.Info("closing keep-alive")
+			return
 		case <-ticker.C:
 			log.Trace("Pinging peer")
 			err := c.Ping()


### PR DESCRIPTION
This updates `mergemock` to [The Talladega Curse](https://github.com/ethereum/execution-apis/releases/tag/v1.0.0-alpha.4) release of the Engine API.