### PR TITLE
Add EIP-4399 support

### DIFF
--- a/api.go
+++ b/api.go
@@ -254,7 +254,7 @@ func ForkchoiceUpdated(ctx context.Context, cl *rpc.Client, log logrus.Ext1Field
 	}
 }
 
-func BlockToPayload(bl *types.Block, random Bytes32) (*ExecutionPayload, error) {
+func BlockToPayload(bl *types.Block) (*ExecutionPayload, error) {
 	extra := bl.Extra()
 	if len(extra) > 32 {
 		return nil, fmt.Errorf("eth2 merge spec limits extra data to 32 bytes in payload, got %d", len(extra))
@@ -278,7 +278,7 @@ func BlockToPayload(bl *types.Block, random Bytes32) (*ExecutionPayload, error) 
 		StateRoot:     Bytes32(bl.Root()),
 		ReceiptRoot:   Bytes32(bl.ReceiptHash()),
 		LogsBloom:     Bytes256(bl.Bloom()),
-		Random:        random,
+		Random:        Bytes32(bl.MixDigest()),
 		BlockNumber:   Uint64Quantity(bl.NumberU64()),
 		GasLimit:      Uint64Quantity(bl.GasLimit()),
 		GasUsed:       Uint64Quantity(bl.GasUsed()),

--- a/consensus.go
+++ b/consensus.go
@@ -3,12 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"math"
 	"math/big"
 	"mergemock/p2p"
 	"os"
 	"time"
+
+	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -173,7 +174,7 @@ func (c *ConsensusCmd) proofOfWorkPrelogue(log logrus.Ext1FieldLogger) (transiti
 		}
 
 		// announce block
-		newBlock := eth.NewBlockPacket{Block: block, TD: c.mockChain.CurrentTd()}
+		newBlock := eth.NewBlockPacket{Block: block, TD: mc.CurrentTd()}
 		if err := peer.Write66(&newBlock, 23); err != nil {
 			return 0, fmt.Errorf("failed to msg peer: %v", err)
 		}

--- a/consensus.go
+++ b/consensus.go
@@ -9,18 +9,16 @@ import (
 	"os"
 	"time"
 
-	"github.com/ethereum/go-ethereum/ethdb"
-
-	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/eth/protocols/eth"
-	"github.com/ethereum/go-ethereum/p2p/enode"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/sirupsen/logrus"
@@ -129,7 +127,6 @@ func (c *ConsensusCmd) ValidateTimestamp(timestamp uint64, slot uint64) error {
 }
 
 func (c *ConsensusCmd) proofOfWorkPrelogue(log logrus.Ext1FieldLogger) (transitionBlock uint64, err error) {
-
 	// Create a temporary chain around the db, with ethash consensus, to run through the POW part.
 	engine := ethash.New(c.ethashCfg, nil, false)
 
@@ -304,7 +301,7 @@ func (c *ConsensusCmd) RunNode() {
 					uncleBlocks := []*types.Header{} // none in proof of stake
 					creator := TransactionsCreator(dummyTxCreator)
 
-					block, err = c.mockChain.AddNewBlock(parent.Hash(), coinbase, timestamp, gasLimit, creator, extraData, uncleBlocks, true)
+					block, err = c.mockChain.AddNewBlock(parent.Hash(), coinbase, timestamp, gasLimit, creator, [32]byte{}, extraData, uncleBlocks, true)
 					if err != nil {
 						slotLog.WithError(err).Errorf("Failed to add block")
 						continue
@@ -404,7 +401,7 @@ func (c *ConsensusCmd) mockExecution(log logrus.Ext1FieldLogger, block *types.Bl
 	defer cancel()
 
 	// derive the random 32 bytes from the block hash for mocking ease
-	payload, err := BlockToPayload(block, mockRandomValue(block.Hash()))
+	payload, err := BlockToPayload(block)
 
 	if err != nil {
 		log.WithError(err).Error("Failed to convert execution block to execution payload")

--- a/engine.go
+++ b/engine.go
@@ -263,7 +263,7 @@ func (e *EngineBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *Forkchoi
 	extraData := []byte{}
 
 	bl, err := e.mockChain.AddNewBlock(common.BytesToHash(heads.HeadBlockHash[:]), attributes.FeeRecipient, uint64(attributes.Timestamp),
-		gasLimit, txsCreator, extraData, nil, false)
+		gasLimit, txsCreator, attributes.Random, extraData, nil, false)
 
 	if err != nil {
 		// TODO: proper error codes
@@ -271,7 +271,7 @@ func (e *EngineBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *Forkchoi
 		return nil, err
 	}
 
-	payload, err := BlockToPayload(bl, attributes.Random)
+	payload, err := BlockToPayload(bl)
 	if err != nil {
 		plog.WithError(err).Error("Failed to convert block to payload")
 		// TODO: proper error codes


### PR DESCRIPTION
Fixes a smol bug and brings `mergemock` up-to-date with EIP-4399.