### PR TITLE
Change relay to take execution url as a parameter

### DIFF
--- a/api/builder.go
+++ b/api/builder.go
@@ -26,6 +26,7 @@ type ExecutionPayloadHeaderV1 struct {
 	BaseFeePerGas    Uint256Quantity `json:"baseFeePerGas"`
 	BlockHash        common.Hash     `json:"blockHash"`
 	TransactionsRoot Bytes32         `json:"transactionsRoot"`
+	FeeRecipientDiff Uint256Quantity `json:"feeRecipientDiff"`
 }
 
 // See https://github.com/flashbots/mev-boost#signedblindedbeaconblock

--- a/relay.go
+++ b/relay.go
@@ -2,44 +2,42 @@ package main
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	. "mergemock/api"
 	"mergemock/rpc"
 	"net/http"
 
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/params"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/sirupsen/logrus"
 )
 
 type RelayCmd struct {
 	// connectivity options
-	ListenAddr string      `ask:"--listen-addr" help:"Address to bind RPC HTTP server to"`
-	Cors       []string    `ask:"--cors" help:"List of allowable origins (CORS http header)"`
-	Timeout    rpc.Timeout `ask:".timeout" help:"Configure timeouts of the HTTP servers"`
+	ListenAddr    string      `ask:"--listen-addr" help:"Address to bind RPC HTTP server to"`
+	EngineAddr    string      `ask:"--engine" help:"Address of Engine JSON-RPC endpoint to use"`
+	Cors          []string    `ask:"--cors" help:"List of allowable origins (CORS http header)"`
+	Timeout       rpc.Timeout `ask:".timeout" help:"Configure timeouts of the HTTP servers"`
+	JwtSecretPath string      `ask:"--jwt-secret" help:"JWT secret key for authenticated communication"`
 
 	// embed logger options
 	LogCmd `ask:".log" help:"Change logger configuration"`
 
-	close  chan struct{}
-	log    logrus.Ext1FieldLogger
-	ctx    context.Context
-	rpcSrv *rpc.Server
-	srv    *http.Server
+	close     chan struct{}
+	log       logrus.Ext1FieldLogger
+	ctx       context.Context
+	rpcSrv    *rpc.Server
+	srv       *http.Server
+	jwtSecret []byte
 }
 
 func (r *RelayCmd) Default() {
 	r.ListenAddr = "127.0.0.1:28545"
+	r.EngineAddr = "http://127.0.0.1:8550"
 	r.Cors = []string{"*"}
+	r.JwtSecretPath = "jwt.hex"
 
 	r.Timeout.Read = 30 * time.Second
 	r.Timeout.ReadHeader = 10 * time.Second
@@ -56,12 +54,24 @@ func (r *RelayCmd) Run(ctx context.Context, args ...string) error {
 		// Logger wasn't initialized so we can't log. Error out instead.
 		return err
 	}
-	backend, err := NewRelayBackend(r.log)
+
+	jwt, err := loadJwtSecret(r.JwtSecretPath)
+	if err != nil {
+		r.log.WithField("err", err).Fatal("Unable to read JWT secret")
+	}
+	r.jwtSecret = jwt
+	r.log.WithField("val", common.Bytes2Hex(r.jwtSecret[:])).Info("Loaded JWT secret")
+
+	// Connect to execution client engine api
+	engineClient, err := rpc.DialContext(ctx, r.EngineAddr, r.jwtSecret)
+	if err != nil {
+		return err
+	}
+
+	backend, err := NewRelayBackend(ctx, r.log, engineClient)
+
 	if err != nil {
 		r.log.WithField("err", err).Fatal("Unable to initialize backend")
-	}
-	if err := backend.engine.Run(ctx); err != nil {
-		r.log.WithField("err", err).Fatal("Unable to initialize engine")
 	}
 	r.startRPC(ctx, backend)
 	go r.RunNode()
@@ -110,33 +120,46 @@ func (r *RelayCmd) startRPC(ctx context.Context, backend *RelayBackend) {
 
 type RelayBackend struct {
 	log              logrus.Ext1FieldLogger
-	engine           *EngineCmd
 	payloadIdCounter uint64
 	recentPayloads   *lru.Cache
+	engineClient     *rpc.Client
+	ctx              context.Context
 }
 
-func NewRelayBackend(log logrus.Ext1FieldLogger) (*RelayBackend, error) {
-	engine := &EngineCmd{}
-	engine.Default()
-	engine.LogCmd.Default()
-	engine.ListenAddr = "127.0.0.1:28546"
-	engine.WebsocketAddr = "127.0.0.1:28547"
+func NewRelayBackend(ctx context.Context, log logrus.Ext1FieldLogger, engineClient *rpc.Client) (*RelayBackend, error) {
 	cache, err := lru.New(10)
 	if err != nil {
 		return nil, err
 	}
-	return &RelayBackend{log, engine, 0, cache}, nil
+	return &RelayBackend{log, 0, cache, engineClient, ctx}, nil
+}
+
+func (r *RelayBackend) sendForkchoiceUpdated(latest, safe, final Bytes32, attributes *PayloadAttributesV1) (*ForkchoiceUpdatedResult, error) {
+	result, _ := ForkchoiceUpdatedV1(r.ctx, r.engineClient, r.log, latest, safe, final, attributes)
+	if result.Status.Status != ExecutionValid {
+		return nil, fmt.Errorf("Update not considered valid")
+	}
+	return &result, nil
 }
 
 func (r *RelayBackend) GetPayloadHeaderV1(ctx context.Context, id PayloadID) (*ExecutionPayloadHeaderV1, error) {
 	plog := r.log.WithField("payload_id", id)
-	payload, ok := r.recentPayloads.Get(id)
-	if !ok {
-		plog.Warn("Cannot get unknown payload")
-		return nil, &rpc.Error{Err: fmt.Errorf("unknown payload %d", id), Id: int(UnavailablePayload)}
+
+	payload, err := GetPayloadV1(r.ctx, r.engineClient, r.log, id)
+	if err != nil {
+		return nil, err
 	}
+
+	header, err := PayloadToPayloadHeader(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	r.recentPayloads.Add(id, header)
+	r.recentPayloads.Add(payload.BlockHash, payload)
+
 	plog.Info("Consensus client retrieved prepared payload header")
-	return payload.(*ExecutionPayloadHeaderV1), nil
+	return header, nil
 }
 
 func (r *RelayBackend) ProposeBlindedBlockV1(ctx context.Context, block *SignedBlindedBeaconBlock, attributes *SignedBuilderReceipt) (*ExecutionPayloadV1, error) {
@@ -161,49 +184,5 @@ func (r *RelayBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *Forkchoic
 		"attributes": attributes,
 	}).Info("Forkchoice updated")
 
-	if attributes == nil {
-		return &ForkchoiceUpdatedResult{Status: PayloadStatusV1{Status: ExecutionValid, LatestValidHash: &heads.HeadBlockHash}}, nil
-	}
-	idU64 := atomic.AddUint64(&r.payloadIdCounter, 1)
-	var id PayloadID
-	binary.BigEndian.PutUint64(id[:], idU64)
-
-	plog := r.log.WithField("payload_id", id)
-	plog.WithField("attributes", attributes).Info("Preparing new payload")
-
-	gasLimit := r.engine.mockChain().gspec.GasLimit
-	txsCreator := TransactionsCreator{nil, func(config *params.ChainConfig, bc core.ChainContext,
-		statedb *state.StateDB, header *types.Header, cfg vm.Config, accounts []TestAccount) []*types.Transaction {
-		// empty payload
-		// TODO: maybe vary these a little?
-		return nil
-	}}
-	extraData := []byte{}
-
-	bl, err := r.engine.mockChain().AddNewBlock(common.BytesToHash(heads.HeadBlockHash[:]), attributes.SuggestedFeeRecipient, uint64(attributes.Timestamp),
-		gasLimit, txsCreator, attributes.PrevRandao, extraData, nil, false)
-
-	if err != nil {
-		// TODO: proper error codes
-		plog.WithError(err).Error("Failed to create block, cannot build new payload")
-		return nil, err
-	}
-
-	payload, err := BlockToPayload(bl)
-	if err != nil {
-		plog.WithError(err).Error("Failed to convert block to payload")
-		// TODO: proper error codes
-		return nil, err
-	}
-
-	header, err := PayloadToPayloadHeader(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	// Store header by id and full block by hash. This mirrors the retrieval flow.
-	r.recentPayloads.Add(id, header)
-	r.recentPayloads.Add(bl.Hash(), payload)
-
-	return &ForkchoiceUpdatedResult{Status: PayloadStatusV1{Status: ExecutionValid, LatestValidHash: &heads.HeadBlockHash}, PayloadID: &id}, nil
+	return r.sendForkchoiceUpdated(heads.HeadBlockHash, heads.SafeBlockHash, heads.FinalizedBlockHash, attributes)
 }


### PR DESCRIPTION
This is a semi-big change, where instead of running a local execution client inside of the relay, we instead can now point at any arbitrary execution client.

Also contains small fixes to get it working with the latest mev-boost, see https://github.com/flashbots/mev-boost/pull/85