### PR TITLE
added ci + make lint, fixed staticcheck complaints

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,39 @@
+name: Go
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run unit tests and generate the coverage report
+        run: make test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.1
+
+      - name: Lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+GIT_VER := $(shell git describe --tags --always --dirty="-dev")
+
+all: clean build
+
+v:
+	@echo "Version: ${GIT_VER}"
+
+test:
+	go test ./...
+
+lint:
+	gofmt -d ./
+	go vet ./...
+	staticcheck ./...

--- a/api/engine.go
+++ b/api/engine.go
@@ -85,10 +85,7 @@ func (params *ExecutionPayloadV1) ValidateHash() bool {
 		Extra:       params.ExtraData,
 		MixDigest:   params.Random,
 	}
-	if header.Hash() != common.Hash(params.BlockHash) {
-		return false
-	}
-	return true
+	return header.Hash() == common.Hash(params.BlockHash)
 }
 
 type ExecutePayloadStatus string

--- a/consensus.go
+++ b/consensus.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	. "mergemock/api"
+	"mergemock/api"
 	"mergemock/p2p"
 	"mergemock/rpc"
 	"os"
@@ -58,7 +58,7 @@ type ConsensusCmd struct {
 	db        ethdb.Database
 
 	ethashCfg ethash.Config
-	peer      *p2p.Conn
+	// peer      *p2p.Conn
 
 	mockChain *MockChain
 }
@@ -225,7 +225,7 @@ func (c *ConsensusCmd) RunNode() {
 			pow: ethash.New(c.ethashCfg, nil, false),
 			log: c.log,
 		}
-		payloadId = make(chan PayloadID)
+		payloadId = make(chan api.PayloadID)
 	)
 	defer slots.Stop()
 
@@ -292,7 +292,7 @@ func (c *ConsensusCmd) RunNode() {
 			// Send bad hash
 			if c.RNG.Float64() < c.Freq.InvalidHashFreq {
 				c.log.Info("Sending payload with invalid hash")
-				payload := &ExecutionPayloadV1{
+				payload := &api.ExecutionPayloadV1{
 					ParentHash:    c.mockChain.CurrentHeader().Hash(),
 					FeeRecipient:  common.Address{},
 					Number:        c.mockChain.CurrentHeader().Number.Uint64(),
@@ -302,7 +302,7 @@ func (c *ConsensusCmd) RunNode() {
 					BaseFeePerGas: c.mockChain.CurrentHeader().BaseFee,
 					BlockHash:     common.HexToHash("0xdeadbeef"),
 				}
-				go NewPayloadV1(c.ctx, c.engine, c.log, payload)
+				go api.NewPayloadV1(c.ctx, c.engine, c.log, payload)
 				continue
 			}
 
@@ -356,7 +356,7 @@ func (c *ConsensusCmd) RunNode() {
 				latest := block.Hash()
 				// Note: head and safe hash are set to the same hash,
 				// until forkchoice updates are more attestation-weight aware.
-				var attributes *PayloadAttributesV1
+				var attributes *api.PayloadAttributesV1
 				if c.RNG.Float64() < c.Freq.ProposalFreq {
 					// proposing next slot!
 					attributes = c.makePayloadAttributes(slot + 1)
@@ -380,14 +380,14 @@ func (c *ConsensusCmd) RunNode() {
 	}
 }
 
-func (c *ConsensusCmd) sendForkchoiceUpdated(latest, safe, final common.Hash, attributes *PayloadAttributesV1) *PayloadID {
-	result, _ := ForkchoiceUpdatedV1(c.ctx, c.engine, c.log, latest, safe, final, attributes)
-	if result.PayloadStatus.Status != ExecutionValid {
+func (c *ConsensusCmd) sendForkchoiceUpdated(latest, safe, final common.Hash, attributes *api.PayloadAttributesV1) *api.PayloadID {
+	result, _ := api.ForkchoiceUpdatedV1(c.ctx, c.engine, c.log, latest, safe, final, attributes)
+	if result.PayloadStatus.Status != api.ExecutionValid {
 		c.log.WithField("status", result.PayloadStatus).Error("Update not considered valid")
 	}
 	if c.builder != nil && attributes != nil {
-		result, _ := ForkchoiceUpdatedV1(c.ctx, c.builder, c.log, latest, safe, final, attributes)
-		if result.PayloadStatus.Status != ExecutionValid {
+		result, _ := api.ForkchoiceUpdatedV1(c.ctx, c.builder, c.log, latest, safe, final, attributes)
+		if result.PayloadStatus.Status != api.ExecutionValid {
 			c.log.WithField("status", result.PayloadStatus).Error("Update not considered valid")
 		}
 		return result.PayloadID
@@ -395,14 +395,14 @@ func (c *ConsensusCmd) sendForkchoiceUpdated(latest, safe, final common.Hash, at
 	return result.PayloadID
 }
 
-func (c *ConsensusCmd) getMockProposal(ctx context.Context, log logrus.Ext1FieldLogger, payloadId PayloadID) (*ExecutionPayloadV1, error) {
+func (c *ConsensusCmd) getMockProposal(ctx context.Context, log logrus.Ext1FieldLogger, payloadId api.PayloadID) (*api.ExecutionPayloadV1, error) {
 	// If the CL is connected to builder client, request the payload from there.
 	if c.builder != nil {
-		header, err := GetPayloadHeader(c.ctx, c.builder, log, payloadId)
+		header, err := api.GetPayloadHeader(c.ctx, c.builder, log, payloadId)
 		if err != nil {
 			return nil, err
 		}
-		payload, err := ProposePayload(ctx, c.builder, log, header)
+		payload, err := api.ProposePayload(ctx, c.builder, log, header)
 		if err != nil {
 			return nil, err
 		}
@@ -410,14 +410,14 @@ func (c *ConsensusCmd) getMockProposal(ctx context.Context, log logrus.Ext1Field
 	}
 
 	// Otherwise, get payload from EL.
-	payload, err := GetPayloadV1(c.ctx, c.engine, log, payloadId)
+	payload, err := api.GetPayloadV1(c.ctx, c.engine, log, payloadId)
 	if err != nil {
 		return nil, err
 	}
 	return payload, err
 }
 
-func (c *ConsensusCmd) mockProposal(log logrus.Ext1FieldLogger, payloadId PayloadID, slot uint64, consensusFail bool) {
+func (c *ConsensusCmd) mockProposal(log logrus.Ext1FieldLogger, payloadId api.PayloadID, slot uint64, consensusFail bool) {
 	ctx, cancel := context.WithTimeout(c.ctx, time.Second*20)
 	defer cancel()
 
@@ -446,14 +446,14 @@ func (c *ConsensusCmd) mockProposal(log logrus.Ext1FieldLogger, payloadId Payloa
 	}
 
 	// Send it back to execution layer for execution
-	res, err := NewPayloadV1(ctx, c.engine, log, payload)
-	if err == nil && res.Status == ExecutionValid {
+	res, err := api.NewPayloadV1(ctx, c.engine, log, payload)
+	if err == nil && res.Status == api.ExecutionValid {
 		log.WithField("blockhash", block.Hash()).Debug("Processed payload in engine")
 		return
 	}
 	if err != nil {
 		log.WithError(err).Error("Failed to execute payload")
-	} else if res.Status == ExecutionInvalid {
+	} else if res.Status == api.ExecutionInvalid {
 		log.WithField("blockhash", block.Hash()).Error("Engine just produced payload and failed to execute it after!")
 	} else {
 		log.WithField("status", res.Status).Error("Unrecognized execution status")
@@ -466,14 +466,14 @@ func (c *ConsensusCmd) mockExecution(log logrus.Ext1FieldLogger, block *types.Bl
 	defer cancel()
 
 	// derive the random 32 bytes from the block hash for mocking ease
-	payload, err := BlockToPayload(block)
+	payload, err := api.BlockToPayload(block)
 
 	if err != nil {
 		log.WithError(err).Error("Failed to convert execution block to execution payload")
 		return
 	}
 
-	NewPayloadV1(ctx, c.engine, log, payload)
+	api.NewPayloadV1(ctx, c.engine, log, payload)
 }
 
 func dummyTxCreator(config *params.ChainConfig, bc core.ChainContext, statedb *state.StateDB, header *types.Header, cfg vm.Config, accounts []TestAccount) []*types.Transaction {
@@ -510,10 +510,10 @@ func (c *ConsensusCmd) Close() error {
 	return nil
 }
 
-func (c *ConsensusCmd) makePayloadAttributes(slot uint64) *PayloadAttributesV1 {
+func (c *ConsensusCmd) makePayloadAttributes(slot uint64) *api.PayloadAttributesV1 {
 	var prevRandao common.Hash
 	c.RNG.Read(prevRandao[:])
-	return &PayloadAttributesV1{
+	return &api.PayloadAttributesV1{
 		Timestamp:             c.SlotTimestamp(slot),
 		PrevRandao:            prevRandao,
 		SuggestedFeeRecipient: common.Address{0x13, 0x37},

--- a/engine.go
+++ b/engine.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
-	. "mergemock/api"
+	"mergemock/api"
 	"mergemock/rpc"
 	"net/http"
 	"sync/atomic"
@@ -100,16 +100,10 @@ func (c *EngineCmd) RunNode() {
 	go c.srv.ListenAndServe()
 	go c.wsSrv.ListenAndServe()
 
-	for {
-		select {
-		case <-c.close:
-			c.rpcSrv.Stop()
-			c.srv.Close()
-			c.wsSrv.Close()
-			return
-			// TODO: any other tasks to run in this loop? mock sync changes?
-		}
-	}
+	<-c.close
+	c.rpcSrv.Stop()
+	c.srv.Close()
+	c.wsSrv.Close()
 }
 
 func (c *EngineCmd) Close() error {
@@ -183,31 +177,31 @@ func NewEngineBackend(log logrus.Ext1FieldLogger, mock *MockChain) (*EngineBacke
 	return &EngineBackend{log, mock, 0, cache}, nil
 }
 
-func (e *EngineBackend) GetPayloadV1(ctx context.Context, id PayloadID) (*ExecutionPayloadV1, error) {
+func (e *EngineBackend) GetPayloadV1(ctx context.Context, id api.PayloadID) (*api.ExecutionPayloadV1, error) {
 	plog := e.log.WithField("payload_id", id)
 
 	payload, ok := e.recentPayloads.Get(id)
 	if !ok {
 		plog.Warn("Cannot get unknown payload")
-		return nil, &rpc.Error{Err: fmt.Errorf("unknown payload %d", id), Id: int(UnavailablePayload)}
+		return nil, &rpc.Error{Err: fmt.Errorf("unknown payload %d", id), Id: int(api.UnavailablePayload)}
 	}
 
 	plog.Info("Consensus client retrieved prepared payload")
-	return payload.(*ExecutionPayloadV1), nil
+	return payload.(*api.ExecutionPayloadV1), nil
 }
 
-func (e *EngineBackend) NewPayloadV1(ctx context.Context, payload *ExecutionPayloadV1) (*PayloadStatusV1, error) {
+func (e *EngineBackend) NewPayloadV1(ctx context.Context, payload *api.ExecutionPayloadV1) (*api.PayloadStatusV1, error) {
 	log := e.log.WithField("block_hash", payload.BlockHash)
 	if !payload.ValidateHash() {
-		return &PayloadStatusV1{Status: ExecutionInvalidBlockHash}, nil
+		return &api.PayloadStatusV1{Status: api.ExecutionInvalidBlockHash}, nil
 	}
 	parent := e.mockChain.chain.GetHeaderByHash(payload.ParentHash)
 	if parent == nil {
 		log.WithField("parent_hash", payload.ParentHash.String()).Warn("Cannot execute payload, parent is unknown")
-		return &PayloadStatusV1{Status: ExecutionSyncing}, nil
+		return &api.PayloadStatusV1{Status: api.ExecutionSyncing}, nil
 	} else if parent.Difficulty.Cmp(e.mockChain.gspec.Config.TerminalTotalDifficulty) < 0 {
 		log.WithField("parent_hash", payload.ParentHash.String()).Warn("Parent block not yet at TTD")
-		return &PayloadStatusV1{Status: ExecutionInvalidTerminalBlock}, nil
+		return &api.PayloadStatusV1{Status: api.ExecutionInvalidTerminalBlock}, nil
 	}
 
 	_, err := e.mockChain.ProcessPayload(payload)
@@ -217,10 +211,10 @@ func (e *EngineBackend) NewPayloadV1(ctx context.Context, payload *ExecutionPayl
 		return nil, err
 	}
 	log.Info("Executed payload")
-	return &PayloadStatusV1{Status: ExecutionValid}, nil
+	return &api.PayloadStatusV1{Status: api.ExecutionValid}, nil
 }
 
-func (e *EngineBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *ForkchoiceStateV1, attributes *PayloadAttributesV1) (*ForkchoiceUpdatedResult, error) {
+func (e *EngineBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *api.ForkchoiceStateV1, attributes *api.PayloadAttributesV1) (*api.ForkchoiceUpdatedResult, error) {
 	e.log.WithFields(logrus.Fields{
 		"head":       heads.HeadBlockHash,
 		"safe":       heads.SafeBlockHash,
@@ -229,10 +223,10 @@ func (e *EngineBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *Forkchoi
 	}).Info("Forkchoice updated")
 
 	if attributes == nil {
-		return &ForkchoiceUpdatedResult{PayloadStatus: PayloadStatusV1{Status: ExecutionValid, LatestValidHash: &heads.HeadBlockHash}}, nil
+		return &api.ForkchoiceUpdatedResult{PayloadStatus: api.PayloadStatusV1{Status: api.ExecutionValid, LatestValidHash: &heads.HeadBlockHash}}, nil
 	}
 	idU64 := atomic.AddUint64(&e.payloadIdCounter, 1)
-	var id PayloadID
+	var id api.PayloadID
 	binary.BigEndian.PutUint64(id[:], idU64)
 
 	plog := e.log.WithField("payload_id", id)
@@ -256,7 +250,7 @@ func (e *EngineBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *Forkchoi
 		return nil, err
 	}
 
-	payload, err := BlockToPayload(bl)
+	payload, err := api.BlockToPayload(bl)
 	if err != nil {
 		plog.WithError(err).Error("Failed to convert block to payload")
 		// TODO: proper error codes
@@ -266,5 +260,5 @@ func (e *EngineBackend) ForkchoiceUpdatedV1(ctx context.Context, heads *Forkchoi
 	// store in cache for later retrieval
 	e.recentPayloads.Add(id, payload)
 
-	return &ForkchoiceUpdatedResult{PayloadStatus: PayloadStatusV1{Status: ExecutionValid, LatestValidHash: &heads.HeadBlockHash}, PayloadID: &id}, nil
+	return &api.ForkchoiceUpdatedResult{PayloadStatus: api.PayloadStatusV1{Status: api.ExecutionValid, LatestValidHash: &heads.HeadBlockHash}, PayloadID: &id}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -45,14 +45,9 @@ require (
 require github.com/golang-jwt/jwt/v4 v4.3.0
 
 require (
-	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c // indirect
-	github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
-	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/tools v0.1.0 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -102,16 +102,12 @@ github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaB
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c h1:CndMRAH4JIwxbW8KYq6Q+cGWcGHz0FjGR3QqcInWcW0=
-github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgxrzK5E1fW7RQGeDwE8F/ZZnUYc=
-github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
@@ -412,7 +408,6 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -536,7 +531,6 @@ golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200108203644-89082a384178/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 		return nil
 	}
 
-	starter := make(chan start, 0)
+	starter := make(chan start)
 
 	// run command in the background, so we can stop it at any time
 	go func() {
@@ -71,17 +71,15 @@ func main() {
 			if cmd, err := start.cmd, start.err; err == nil {
 				// if the command is long-running and closeable later on, then have the interrupt close it.
 				if cl, ok := cmd.Command.(io.Closer); ok {
-					select {
-					case <-interrupt:
-						err := cl.Close()
-						cancel()
-						if err != nil {
-							_, _ = fmt.Fprintf(os.Stderr, "failed to close node gracefully. Exiting in 5 seconds. %v", err.Error())
-							<-time.After(time.Second * 5)
-							os.Exit(1)
-						}
-						os.Exit(0)
+					<-interrupt
+					err := cl.Close()
+					cancel()
+					if err != nil {
+						_, _ = fmt.Fprintf(os.Stderr, "failed to close node gracefully. Exiting in 5 seconds. %v", err.Error())
+						<-time.After(time.Second * 5)
+						os.Exit(1)
 					}
+					os.Exit(0)
 				} else {
 					os.Exit(0)
 				}

--- a/mock.go
+++ b/mock.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"bytes"
-	"crypto/ecdsa"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
-	. "mergemock/api"
+	"mergemock/api"
 	"os"
 	"time"
 
@@ -32,10 +30,10 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-type testAccount struct {
-	pk   *ecdsa.PrivateKey
-	addr common.Address
-}
+// type testAccount struct {
+// 	pk   *ecdsa.PrivateKey
+// 	addr common.Address
+// }
 
 // This implements the execution-block-header verification interface, but omits many of the details:
 // the mock doesn't fully verify, and sealing work of headers is very limited.
@@ -161,20 +159,20 @@ func (e *ExecutionConsensusMock) Close() error {
 var _ consensus.Engine = (*ExecutionConsensusMock)(nil)
 
 // a hack borrowed from the geth core package
-type fakeChainReader struct {
-	config *params.ChainConfig
-}
+// type fakeChainReader struct {
+// 	config *params.ChainConfig
+// }
 
-// Config returns the chain configuration.
-func (cr *fakeChainReader) Config() *params.ChainConfig {
-	return cr.config
-}
+// // Config returns the chain configuration.
+// func (cr *fakeChainReader) Config() *params.ChainConfig {
+// 	return cr.config
+// }
 
-func (cr *fakeChainReader) CurrentHeader() *types.Header                            { return nil }
-func (cr *fakeChainReader) GetHeaderByNumber(number uint64) *types.Header           { return nil }
-func (cr *fakeChainReader) GetHeaderByHash(hash common.Hash) *types.Header          { return nil }
-func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *types.Header { return nil }
-func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
+// func (cr *fakeChainReader) CurrentHeader() *types.Header                            { return nil }
+// func (cr *fakeChainReader) GetHeaderByNumber(number uint64) *types.Header           { return nil }
+// func (cr *fakeChainReader) GetHeaderByHash(hash common.Hash) *types.Header          { return nil }
+// func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *types.Header { return nil }
+// func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
 
 type TraceLogConfig struct {
 	EnableTrace      bool `ask:"--enable" help:"enable tracing"`
@@ -315,7 +313,7 @@ func (c *MockChain) AddNewBlock(parentHash common.Hash, coinbase common.Address,
 	if c.traceOpts.EnableTrace {
 		var buf bytes.Buffer
 		logger.WriteTrace(&buf, stl.StructLogs())
-		c.log.Info("trace:\n" + string(buf.Bytes()))
+		c.log.Info("trace:\n" + buf.String())
 	}
 
 	header.GasUsed = header.GasLimit - uint64(*gasPool)
@@ -404,7 +402,7 @@ func (c *MockChain) MineBlock(parent *types.Header) (*types.Block, error) {
 	return block, nil
 }
 
-func (c *MockChain) ProcessPayload(payload *ExecutionPayloadV1) (*types.Block, error) {
+func (c *MockChain) ProcessPayload(payload *api.ExecutionPayloadV1) (*types.Block, error) {
 	parent := c.chain.GetHeaderByHash(payload.ParentHash)
 	if parent == nil {
 		return nil, fmt.Errorf("unknown parent %s", payload.ParentHash)
@@ -472,7 +470,7 @@ func (c *MockChain) ProcessPayload(payload *ExecutionPayloadV1) (*types.Block, e
 	if c.traceOpts.EnableTrace {
 		var buf bytes.Buffer
 		logger.WriteTrace(&buf, stl.StructLogs())
-		c.log.Info("trace:\n" + string(buf.Bytes()))
+		c.log.Info("trace:\n" + buf.String())
 	}
 
 	// verify state root is correct, and build the block
@@ -552,10 +550,10 @@ func LoadGenesisConfig(path string) (*core.Genesis, error) {
 	return &genesis, nil
 }
 
-func mockRandomValue(seed [32]byte) [32]byte {
-	h := sha256.New()
-	h.Write(seed[:])
-	var random common.Hash
-	copy(random[:], h.Sum(nil))
-	return random
-}
+// func mockRandomValue(seed [32]byte) [32]byte {
+// 	h := sha256.New()
+// 	h.Write(seed[:])
+// 	var random common.Hash
+// 	copy(random[:], h.Sum(nil))
+// 	return random
+// }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -244,9 +244,9 @@ func (e *Error) Error() string  { return e.err.Error() }
 func (e *Error) Code() int      { return -1 }
 func (e *Error) String() string { return e.Error() }
 
-func errorf(format string, args ...interface{}) *Error {
-	return &Error{fmt.Errorf(format, args...)}
-}
+// func errorf(format string, args ...interface{}) *Error {
+// 	return &Error{fmt.Errorf(format, args...)}
+// }
 
 // Hello is the RLP structure of the protocol handshake.
 type Hello struct {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -50,7 +50,7 @@ func (c *Client) Close() {
 
 // IssueJwtToken creates a new token with IssuedAt set to time.Now().
 func IssueJwtToken() *jwt.Token {
-	claims := jwt.RegisteredClaims{IssuedAt: &jwt.NumericDate{time.Now()}}
+	claims := jwt.RegisteredClaims{IssuedAt: jwt.NewNumericDate(time.Now())}
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 }
 


### PR DESCRIPTION
This PR adds a Makefile with `make lint` and `make test`, and fixes all complaints by `gofmt`, `go vet` and `[staticcheck](https://staticcheck.io/)`. Adds a Github CI workflow.

Linting does the following commands: 
```bash
gofmt -d ./
go vet ./...
staticcheck ./...
```

Not sure this is something you want, but thought I might as well offer it as contribution :)