### PR TITLE
Fix extra write to http writer

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -423,6 +423,7 @@ func (c *ConsensusCmd) getMockProposal(ctx context.Context, log logrus.Ext1Field
 		if err != nil {
 			return nil, err
 		}
+		c.log.WithField("hash", payload.BlockHash.Hex()).Info("received payload from builder")
 		return payload, err
 	}
 

--- a/relay.go
+++ b/relay.go
@@ -316,5 +316,4 @@ func (r *RelayBackend) handleGetPayload(w http.ResponseWriter, req *http.Request
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Getting this in the logs for `GetPayload`:

```
2022/05/13 15:39:11 http: superfluous response.WriteHeader call from main.(*responseWriter).WriteHeader (utils.go:34)
```