### PR TITLE
fix domain handling when signing

### DIFF
--- a/types/signing.go
+++ b/types/signing.go
@@ -15,7 +15,7 @@ var (
 
 const (
 	DomainTypeBeaconProposer DomainType = 0x00000000
-	DomainTypeAppBuilder     DomainType = 0x00000001
+	DomainTypeAppBuilder     DomainType = 16777216
 )
 
 func init() {


### PR DESCRIPTION
the current implementation writes `1` as little-endian which sets the "low" bit when in fact we want to set the "high" bit.

this PR fixes this so that it aligns w/ the consensus-specs

fwiw other Go impls like `zrnt` just use direct bytes which are copied into the domain, no need to bother with endianness