### PR TITLE
Use bytes instead of int of domain type

### DIFF
--- a/types/signing.go
+++ b/types/signing.go
@@ -1,21 +1,17 @@
 package types
 
 import (
-	"encoding/binary"
-
 	"github.com/prysmaticlabs/prysm/crypto/bls"
 )
 
 type Domain [32]byte
-type DomainType uint32
+type DomainType [4]byte
 
 var (
 	DomainBuilder Domain
-)
 
-const (
-	DomainTypeBeaconProposer DomainType = 0x00000000
-	DomainTypeAppBuilder     DomainType = 0x00000001
+	DomainTypeBeaconProposer DomainType = DomainType{0x00, 0x00, 0x00, 0x00}
+	DomainTypeAppBuilder     DomainType = DomainType{0x00, 0x00, 0x00, 0x01}
 )
 
 func init() {
@@ -47,7 +43,7 @@ func ComputeDomain(dt DomainType, forkVersion uint32, genesisValidatorsRoot *Roo
 	}).HashTreeRoot()
 
 	var domain [32]byte
-	binary.LittleEndian.PutUint32(domain[0:4], uint32(dt))
+	copy(domain[0:4], dt[:])
 	copy(domain[4:], forkDataRoot[0:28])
 
 	return domain

--- a/types/signing_test.go
+++ b/types/signing_test.go
@@ -23,12 +23,11 @@ func TestVerifySignature(t *testing.T) {
 		Timestamp:    1652369368,
 		Pubkey:       PublicKey{0x0d},
 	}
-	domain := ComputeApplicationDomain(0x01)
-	root, err := ComputeSigningRoot(msg, domain)
+	root, err := ComputeSigningRoot(msg, DomainBuilder)
 	require.NoError(t, err)
 
 	sig := sk.Sign(root[:])
-	ok, err := VerifySignature(msg, domain, pk, sig.Marshal())
+	ok, err := VerifySignature(msg, DomainBuilder, pk, sig.Marshal())
 	require.NoError(t, err)
 	require.True(t, ok)
 }


### PR DESCRIPTION
Alternative to #37 -- I think it's better to keep the same format as the spec, e.g. `0x00000001` little-endian. This PR does that by making `DomainType` a `[4]byte` array instead of int.