### PR TITLE
Adjust signing domain for RegisterValidator and GetHeader

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -266,7 +266,8 @@ func (r *RelayBackend) handleGetHeader(w http.ResponseWriter, req *http.Request)
 		Value:  [32]byte{0x1},
 		Pubkey: r.pk,
 	}
-	msg, err := types.ComputeSigningRoot(&bid, types.DomainBuilder)
+	domain := types.ComputeDomain(types.DomainTypeBeaconProposer, version.Bellatrix, &r.genesisValidatorsRoot)
+	msg, err := types.ComputeSigningRoot(&bid, domain)
 	if err != nil {
 		plog.Warn("cannot compute signing root")
 		http.Error(w, "cannot compute signing root", http.StatusBadRequest)

--- a/relay_test.go
+++ b/relay_test.go
@@ -207,7 +207,8 @@ func TestGetHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, parentHash[:], bid.Data.Message.Header.ParentHash[:], "didn't build on expected parent")
-	ok, err := types.VerifySignature(bid.Data.Message, types.DomainBuilder, relay.pk[:], bid.Data.Signature[:])
+	domain := types.ComputeDomain(types.DomainTypeBeaconProposer, version.Bellatrix, &relay.genesisValidatorsRoot)
+	ok, err := types.VerifySignature(bid.Data.Message, domain, relay.pk[:], bid.Data.Signature[:])
 	require.NoError(t, err, "error verifying signature")
 	require.True(t, ok, "bid signature not valid")
 


### PR DESCRIPTION
Update GetHeader to match the spec, should be verified against proposer signing domain.

Reference: https://github.com/ethereum/builder-specs/blob/main/specs/builder.md#containers and https://github.com/ethereum/builder-specs/blob/main/specs/builder.md#signing