### PR TITLE
Add flag to provide custom relay's secret key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ data
 ethash
 jwt.hex
 /mergemock
+
+# IDEs
+.idea/

--- a/relay.go
+++ b/relay.go
@@ -51,7 +51,7 @@ type RelayCmd struct {
 
 	GenesisValidatorsRoot string `ask:"--genesis-validators-root" help:"Root of genesis validators"`
 
-	SecretKey string `ask:"--private-key" help:"The relay's secret key used to sign payloads"`
+	SecretKey string `ask:"--secret-key" help:"The relay's secret key used to sign payloads"`
 
 	close chan struct{}
 	log   *logrus.Logger

--- a/relay_test.go
+++ b/relay_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"mergemock/api"
@@ -30,7 +31,10 @@ type testRelayBackend struct {
 }
 
 func newTestRelay(t *testing.T) *testRelayBackend {
-	relay, err := NewRelayBackend(logrus.New(), "127.0.0.1:38551", "127.0.0.1:38552", "0x1234000000000000000000000000000000000000000000000000000000000000")
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+
+	relay, err := NewRelayBackend(logrus.New(), "127.0.0.1:38551", "127.0.0.1:38552", "0x1234000000000000000000000000000000000000000000000000000000000000", hex.EncodeToString(sk.Marshal()))
 	if err != nil {
 		t.Fatal("unable to create relay")
 	}


### PR DESCRIPTION
## Description

I wanted to have a way to provide my own private key to the relay instead of using the random one generated at startup.
It's related to [this PR on mev-boost](https://github.com/flashbots/mev-boost/pull/138), where mergemock tests are failing because :

- mev-boost is launched without a proper public key for its relay
- we cannot know it because mergemock's relay creates a random one

I added a new flag to mergemock's relay : `--private-key` which takes a private key as a string.

By default, a random one is generated anyway.
