### PR TITLE
Add missing clean rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,35 @@
 GIT_VER := $(shell git describe --tags --always --dirty="-dev")
 
+.PHONY: all
 all: clean build
 
+.PHONY: v
 v:
 	@echo "Version: ${GIT_VER}"
 
+.PHONY: build
 build:
 	go build . mergemock
 
+.PHONY: test
 test:
 	go test ./...
 
+.PHONY: lint
 lint:
 	gofmt -d ./
 	go vet ./...
 	staticcheck ./...
 
+.PHONY: generate-ssz
 generate-ssz:
 	rm -f types/builder_encoding.go types/signing_encoding.go
 	sszgen --path types --include ../go-ethereum/common/hexutil --objs Eth1Data,BeaconBlockHeader,SignedBeaconBlockHeader,ProposerSlashing,Checkpoint,AttestationData,IndexedAttestation,AttesterSlashing,Attestation,Deposit,VoluntaryExit,SyncAggregate,ExecutionPayloadHeader,VersionedExecutionPayloadHeader,BlindedBeaconBlockBody,BlindedBeaconBlock,RegisterValidatorRequestMessage,BuilderBid,SignedBuilderBid,SigningData,forkData,transactions
 
+.PHONY: generate
 generate: generate-ssz
 	go generate ./...
+
+.PHONY: clean
+clean:
+	rm -rf mergemock


### PR DESCRIPTION
When building this project, I encountered the following problem:

```
$ make
make: *** No rule to make target `clean', needed by `all'.  Stop.
$ make all
make: *** No rule to make target `clean', needed by `all'.  Stop.
```

This is because the `all` rule requires `clean` but this rule does not exist.

https://github.com/protolambda/mergemock/blob/ccac956b1abddd73670d0c8fa3d503586b1801b6/Makefile#L3

Also, make targets phony. Not really necessary, but it doesn't hurt.