### PR TITLE
Allow same timestamp for validator registrations

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -216,7 +216,7 @@ func (r *RelayBackend) handleRegisterValidator(w http.ResponseWriter, req *http.
 			return
 		}
 		if prefs, ok := r.registrations[reg.Message.Pubkey]; ok {
-			if prefs.Timestamp <= reg.Message.Timestamp {
+			if prefs.Timestamp > reg.Message.Timestamp {
 				http.Error(w, errInvalidTimestamp.Error(), http.StatusBadRequest)
 				return
 			}

--- a/relay_test.go
+++ b/relay_test.go
@@ -161,7 +161,7 @@ func TestValidatorRegistration(t *testing.T) {
 	msg := &types.RegisterValidatorRequestMessage{
 		FeeRecipient: types.Address{0x42},
 		GasLimit:     15_000_000,
-		Timestamp:    msg1.Timestamp,
+		Timestamp:    msg1.Timestamp - 1,
 		Pubkey:       pubkey1,
 	}
 	root, err := types.ComputeSigningRoot(msg, types.DomainBuilder)


### PR DESCRIPTION
Change logic to only fail if previously sent registration has a bigger timestamp than current one